### PR TITLE
added case insensitivity to the uploaduserkey

### DIFF
--- a/lib/Controller/KeyController.php
+++ b/lib/Controller/KeyController.php
@@ -66,7 +66,7 @@ class KeyController extends Controller {
 			$keyinfo = $this->gpg->keyinfo($fingerprint, $this->userId);
 			$key_for_email = false;
 			foreach ($keyinfo[0]['uids'] as $uid) {
-				if ($uid['email'] === $email) {
+				if (strtolower($uid['email']) === strtolower($email)) {
 					$key_for_email = true;
 					break;
 				}


### PR DESCRIPTION
Added case insensitivity to the uploaduserkey function to allow gpgkey and valid email to ignore case. This will allow it to import keys for email addresses that have varying capitalization.  This should work fine as email addresses are not case sensitive, and other email clients tend to handle this just fine.

Not sure if you're interested in this functionality or not per our prior conversation about it, but so far I have tested it and everything seems fine.  I'll probably maintain this change on my server, as long as is possible, because I feel it alleviates confusion for my users.