### PR TITLE
Close #10 Increase textarea width on settings page

### DIFF
--- a/css/adminSettings.css
+++ b/css/adminSettings.css
@@ -1,0 +1,3 @@
+.server_pubkey, .server_keyinfo {
+    width: 400px;
+}

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -3,7 +3,7 @@
 /** @var $_ array */
 
 //script('myappid', 'admin');         // adds a JavaScript file
-//style('survey_client', 'admin');    // adds a CSS file
+style('gpgmailer', 'adminSettings');    // adds a CSS file
 ?>
 
 <div id="gpgmailer" class="section">


### PR DESCRIPTION
See #10.
Now the textareas on the admin settings page have the same width as on the user settings page.

![image](https://user-images.githubusercontent.com/10116544/102813180-a2df5e80-43c8-11eb-8ec1-8ae3a04a6cc3.png)
