### PR TITLE
Add website / repository url to appinfo/info.xml

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,9 @@ This App depends on gnupg.</description>
     <category>security</category>
     <category>social</category>
     <category>tools</category>
+    <website>https://github.com/tacruc/gpgmailer</website>
     <bugs>https://github.com/tacruc/gpgmailer/issues</bugs>
+    <repository>https://github.com/tacruc/gpgmailer</repository>
     <dependencies>
         <nextcloud min-version="19" max-version="21"/>
         <lib min-version="1.4.0">gnupg</lib>


### PR DESCRIPTION
Allows Nextcloud / the app store to show links linking to the website / repository of the plugin.

It is common on other apps that if they do not have a better website suited to present the app, that the website key links to the main page of the repository. This at least allows technical users to gather more information about the app like for example examining the source code or reading a changelog (even if the only changelog are the commits between tags).